### PR TITLE
RCIAM-530_comanage-registry-plugin-LinkOrgIdentityEnroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.3] - 2020-03-02
+
+### Changed
+
+- Extended the plugin in order to support RCIAM Assurance Model. The Model is associated with OrgIdentities.
+
 ## [v0.5.2] - 2020-02-08
 
 ### Fixed

--- a/Model/LinkOrgIdentityEnroller.php
+++ b/Model/LinkOrgIdentityEnroller.php
@@ -569,6 +569,20 @@ class LinkOrgIdentityEnroller extends AppModel
       }
     }
 
+    // XXX RCIAM specific Model
+    if(!empty($cmp_attibutes_list['eduPersonAssurance'])
+       && in_array("Assurance", App::objects('Model'))) {
+      $association_data['Assurance'] = array();
+      $assurance_values = explode(';', $cmp_attibutes_list['eduPersonAssurance']);
+      foreach($assurance_values as $val) {
+        $association_data['Assurance'][] = array(
+          'value' => $val,
+          'type' => AssuranceComponentEnum::AssuranceProfile,
+          'actor_identifier' => $cmp_attibutes_list[$user_id_attribute],
+        );
+      }
+    }
+
     $this->log(__METHOD__ . '::OrgIdentity Data => ' . print_r($association_data, true), LOG_DEBUG);
 
     // The options for the save association


### PR DESCRIPTION
Extended the plugin in order to support RCIAM Assurance Model. The Model is associated to OrgIdentities.